### PR TITLE
Prepend rbenv version's man dir, don't overwrite

### DIFF
--- a/bin/rbenv-man
+++ b/bin/rbenv-man
@@ -2,4 +2,4 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-exec man -M "$RBENV_ROOT/versions/$(rbenv-version-name)/share/man" "$@"
+exec man -M "${RBENV_ROOT}/versions/$(rbenv-version-name)/share/man:${MANPATH}" "$@"


### PR DESCRIPTION
`MANPATH` is a colon-separated list of paths to search when looking for manpages. We don't want to _overwrite_ the default `MANPATH` (as `-M` does), but rather we just want to prepend the currently-active ruby's manpath.
