### PR TITLE
Use rbenv-prefix to find ruby version location

### DIFF
--- a/bin/rbenv-man
+++ b/bin/rbenv-man
@@ -2,4 +2,4 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-exec man -M "${RBENV_ROOT}/versions/$(rbenv-version-name)/share/man:${MANPATH}" "$@"
+exec man -M "$(rbenv-prefix)/share/man:${MANPATH}" "$@"


### PR DESCRIPTION
I'm not sure why I didn't do this yesterday. rbenv-prefix is the provided mechanism for finding the root of the selected ruby version.

Also fixes #3 but does so more correctly (rather than by happenstance)
